### PR TITLE
Fix recording state handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed preferences access issues during recording session setup
 - Added more robust bitrate and quality settings based on selected preferences
 - Improved handling of video dimensions for Retina displays
+- Fixed bug where `RecordingManager` did not set `isRecording` after starting,
+  preventing timer and output files from being produced
 
 ### Planned
 - Full featured area selection tool with visual selection interface

--- a/DidYouGet/DidYouGet/Models/RecordingManager.swift
+++ b/DidYouGet/DidYouGet/Models/RecordingManager.swift
@@ -201,11 +201,14 @@ class RecordingManager: ObservableObject {
         // Set up capture session with comprehensive error handling
         print("Setting up capture session")
         try await setupCaptureSession()
-        
+
         // Start input tracking if enabled
         print("Starting input tracking")
         startInputTracking()
-        
+
+        // Mark recording state as active only after everything succeeded
+        isRecording = true
+
         print("Recording started successfully")
     }
     

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -320,6 +320,7 @@
 4. **Improved logging** - Added comprehensive logging throughout the recording process for better diagnostics
 5. **Preferences handling** - Fixed issues where preferences weren't correctly accessed during recording
 6. **Stream output handling** - Enhanced frame and sample buffer processing to properly handle video and audio
+7. **Recording state bug** - Fixed issue where recording state wasn't set after starting, causing timer and output files to fail
 
 ### Next Steps
 


### PR DESCRIPTION
## Summary
- ensure `RecordingManager` sets `isRecording` when starting
- document fix in progress tracker
- log fix in CHANGELOG

## Testing
- `swift test` *(fails: couldn't build due to missing resources)*

## Summary by Sourcery

Fix recording state handling in RecordingManager by marking `isRecording` only after successful session setup and update documentation accordingly

Bug Fixes:
- Set `isRecording` to true after starting capture session to allow timers and output files to function

Documentation:
- Document recording state fix in CHANGELOG.md and PROGRESS.md